### PR TITLE
Mono support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ gulp.task('unit-test', function () {
       useMono: true,
       options: {
         nologo: true,
-				noshadow: true
+	noshadow: true
       }      
     }));
 });
 ```
 This would result in the following command:
 
-```bash
-    mono "./packages/xunit.runner.console.2.1.0/tools/xunit.console.exe" -nologo -noshadow "/path/to/src/Database.Test.dll" "/path/to/src/Services.Test.dll"
+```shell
+mono "./packages/xunit.runner.console.2.1.0/tools/xunit.console.exe" -nologo -noshadow "/path/to/src/Database.Test.dll" "/path/to/src/Services.Test.dll"
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ gulp.task('unit-test', function () {
       useMono: true,
       options: {
         nologo: true,
-	noshadow: true
+	    noshadow: true
       }      
     }));
 });

--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ This would result in the following command:
 C:/xunit/bin/xunit-console.exe /nologo /config:"Release" /transform:"myTransform.xslt" "C:\full\path\to\Database.Test.dll" "C:\full\path\to\Services.Test.dll"
 ```
 
+### Mono
+
+Running xUnit on Mono for those needed running it on Mac and Linux. 
+Probably will run only with xUnit 2.1.0+, because of some issues with xUnit and mono.
+Use latest mono possible e.g. `4.4.1` or above.
+
+```javascript
+var gulp = require('gulp'),
+    xunit = require('gulp-xunit-runner');
+
+gulp.task('unit-test', function () {
+  return gulp.src(['**/*.Test.dll'], {read: false})
+    .pipe(xunit({
+      executable: './packages/xunit.runner.console.2.1.0/tools/xunit.console.exe',
+      useMono: true,
+      options: {
+        nologo: true,
+				noshadow: true
+      }      
+    }));
+});
+```
+This would result in the following command:
+
+```bash
+    mono "./packages/xunit.runner.console.2.1.0/tools/xunit.console.exe" -nologo -noshadow "/path/to/src/Database.Test.dll" "/path/to/src/Services.Test.dll"
+```
+
 ## Options
 
 Below are all avialable options.
@@ -70,6 +98,14 @@ xunit({
     // The XUnit bin folder or the full path of the console runner.
     // If not specified the XUnit bin folder must be in the `PATH`.
     executable: 'path to xunit console runner',
+
+    // is xUnit runnnig on Mono. 
+    // Probably will work with xUnit 2.1.0+. 
+    // Mac and Linux only, not sure about Windows.
+    // Assumes that 'mono' command is in the `PATH`.
+    // `false` by default.
+    useMono: true
+             false,
 
     // The options below map directly to the XUnit console runner. See here
     // for more info: http://www.xunit.org/index.php?p=consoleCommandLine&r=2.6.3

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var runner = function gulpXunitRunner(opts) {
 	return stream;
 };
 
-runner.getExecutable = function (options) {
+runner.getExec = function (options) {
 	
 	var consoleRunner = options.platform === 'x86' ? XUNIT_X86_CONSOLE : XUNIT_CONSOLE;
 	if (!options.executable) return consoleRunner;
@@ -45,13 +45,22 @@ runner.getExecutable = function (options) {
 		path.join(executable, consoleRunner) : executable;
 };
 
+runner.getExecutable = function (options) {
+	if (options.useMono === true) { return 'mono'; }
+	return runner.getExec(options);
+};
+
 runner.getArguments = function (options, assemblies) {
 	var args = [];
-	
+
 	args = args.concat(assemblies);
 
 	if (options.options) {
 		args = args.concat(parseSwitches(options.options));
+	}
+
+	if (options.useMono === true) {
+		args.unshift(runner.getExec(options));
 	}
 	
 	return args;

--- a/test/test.js
+++ b/test/test.js
@@ -116,16 +116,25 @@ var path = require('path');
 				expect(xunit.getArguments(opts, assemblies)).to.deep.equal(['First.Test.dll', 'Second.Test.dll']);
 			});
 
-			it('Should work with mono.', function () {
+			it('Should get proper arguments for mono.', function () {
 				opts = {
 					executable: './packages/xunit.runner.console.2.1.0/tools/xunit.console.exe',
 					useMono: true
 				};
 
 				assemblies = ['First.Test.dll', 'Second.Test.dll'];
-
 				expect(xunit.getArguments(opts, assemblies)).to.deep.equal(['./packages/xunit.runner.console.2.1.0/tools/xunit.console.exe','First.Test.dll', 'Second.Test.dll']);
-			});			
+			});	
+
+			it('Should use mono as executable.', function () {
+				opts = {
+					executable: './packages/xunit.runner.console.2.1.0/tools/xunit.console.exe',
+					useMono: true
+				};
+
+				assemblies = ['First.Test.dll', 'Second.Test.dll'];				
+				expect(xunit.getExecutable(opts)).to.equal('mono');
+			});							
 
 			it('Should have correct options with options and assemblies.', function () {
 				opts = {

--- a/test/test.js
+++ b/test/test.js
@@ -116,6 +116,17 @@ var path = require('path');
 				expect(xunit.getArguments(opts, assemblies)).to.deep.equal(['First.Test.dll', 'Second.Test.dll']);
 			});
 
+			it('Should work with mono.', function () {
+				opts = {
+					executable: './packages/xunit.runner.console.2.1.0/tools/xunit.console.exe',
+					useMono: true
+				};
+
+				assemblies = ['First.Test.dll', 'Second.Test.dll'];
+
+				expect(xunit.getArguments(opts, assemblies)).to.deep.equal(['./packages/xunit.runner.console.2.1.0/tools/xunit.console.exe','First.Test.dll', 'Second.Test.dll']);
+			});			
+
 			it('Should have correct options with options and assemblies.', function () {
 				opts = {
 					executable: 'C:\\xunit\\bin\\xunit.console.exe',


### PR DESCRIPTION
Changed a bit this runner to support running`xUnit` with `mono` and for those who needed it on Mac or Linux. Probably will work on Windows with `mono`, but not sure what's the use of it.

Added two tests in `test.js` for testing `mono` behaviour in `getExecutable` and `getArguments`.
All test passed, and files passed linter.

Tested working env:
- Mac OS X 10.11.5
- Mono 4.4.1
- xUnit 2.1.0
- Running as gulp task from VSCode 1.3.1

Not tested on Windows, it should not be broken, but if there is time for anybody to test it, it would be great.
